### PR TITLE
attempting to fix version checking

### DIFF
--- a/lib/mysportsfeeds.rb
+++ b/lib/mysportsfeeds.rb
@@ -30,7 +30,7 @@ class MySportsFeeds
 
     # Make sure the version is supported
     def __verify_version(version)
-        unless %w{1.0 1.1 1.2}.include?(version)
+        unless %w{1.0 1.1 1.2}.include?(version.to_s)
             raise Exception.new("Unrecognized version specified.  Supported versions are: '1.0', '1.1', '1.2'")
         end
     end


### PR DESCRIPTION
For w/e reason the version wasn't being passed in as a string so it was not matching the include? check.  Pulled down, adjusted and install gem via my github repo and now the api call is accurate with v1.2